### PR TITLE
Add GitHub Actions CI build workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,10 +1,13 @@
 name: CI Build
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 concurrency:
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,52 @@
+name: CI Build
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: environment-${{ github.ref }}
+
+permissions:
+  contents: read
+
+env:
+  APP_NAME: "sane_timeout"
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: '1'
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake
+
+    - name: Slack Notify Via Commissioner
+      if: always()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GORDON_DEPLOY_GITHUB_TOKEN }}
+        STATUS: ${{ job.status }}
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        curl --silent --output /dev/stderr -X POST \
+          "https://commissioner.sportngin.com/github_actions/notification" \
+          -H "authorization: Bearer $GITHUB_TOKEN" \
+          -d "payload={ \"repo_slug\": \"$GITHUB_REPOSITORY\",
+                \"commit\": \"$GITHUB_SHA\",
+                \"branch\": \"$BRANCH_NAME\",
+                \"type\": \"$GITHUB_EVENT_NAME\",
+                \"pull_request_number\": \"$PR_NUMBER\",
+                \"build_url\": \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\",
+                \"status_message\": \"${STATUS//success/Passed}\"
+              }"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
+        ruby-version: '3.2'
         bundler-cache: true
 
     - name: Run tests


### PR DESCRIPTION
## Summary
- Add `ci-build.yml` workflow to replace Travis CI
- Runs on all pushes and pull requests

## Test plan
- [ ] Verify CI runs on push to this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)